### PR TITLE
Fixes #15 and #16

### DIFF
--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -262,10 +262,14 @@ export default BaseAuthenticator.extend({
           if (reason.responseJSON) {
             reason = JSON.stringify(reason.responseJSON);
           }
+
           warn(`JWT token could not be refreshed: ${reason}.`, false, {
             id: 'ember-simple-auth-jwt.failedJWTTokenRefresh'
           });
 
+          // The session handles the 'sessionDataInvalidated' event
+          // and will invalidate itself when it is triggered.
+          this.trigger('sessionDataInvalidated');
           reject();
         });
     });

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -173,13 +173,18 @@ export default BaseAuthenticator.extend({
     return new RSVP.Promise((resolve, reject) => {
       fetch(url, options).then((response) => {
         response.text().then((text) => {
-          let json = text ? JSON.parse(text) : {};
-          if (!response.ok) {
-            response.responseJSON = json;
+          try {
+            let json = JSON.parse(text);
+            if (!response.ok) {
+              response.responseJSON = json;
+              reject(response);
+            } else {
+              window.localStorage.setItem('jwtLastRefreshAt', Date.now());
+              resolve(json);
+            }
+          } catch (error) {
+            response.responseText = text;
             reject(response);
-          } else {
-            window.localStorage.setItem('jwtLastRefreshAt', Date.now());
-            resolve(json);
           }
         });
       }).catch(reject);

--- a/tests/acceptance/login-page-test.js
+++ b/tests/acceptance/login-page-test.js
@@ -86,3 +86,23 @@ test('invalid credentials fail to login', function(assert) {
     assert.equal(currentSession(self.application).session.isAuthenticated, false);
   });
 });
+
+test('custom error response from server', function(assert) {
+  let self = this;
+
+  server = new Pretender(function() {
+    this.post(config.authServerTokenEndpoint, () => [401, 'Invalid credentials']);
+  });
+
+  visit('/login');
+  assert.equal(currentSession(self.application).session.isAuthenticated, false);
+
+  fillIn('#identification', 'not');
+  fillIn('#password', 'valid');
+  click('button');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/login');
+    assert.equal(currentSession(self.application).session.isAuthenticated, false);
+  });
+});


### PR DESCRIPTION
#15 Invalidate session if refresh token fails. After the session clears its data (isAuthenticated, authenticator, etc), it will then trigger the 'invalidationSucceeded' event. If using ESA's ApplicationRouteMixin, then the mixin will automatically handle the transitioning to the index route

#16 Handle server responses that are not JSON string. We reject and pass the successful Response we got from fetch(). This gives the user the ability to handle it how they like in their catch block